### PR TITLE
feat(web): add english landing page with about page

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,7 +33,15 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build web
-        run: flutter build web --release --base-href /game-jam-flame-2026/
+        run: flutter build web --release --base-href /game-jam-flame-2026/play/
+
+      - name: Move game under /play and add landing pages
+        run: |
+          temp_dir="$(mktemp -d)"
+          mv build/web/* "$temp_dir"/
+          mkdir -p build/web/play
+          mv "$temp_dir"/* build/web/play/
+          cp -R landing/. build/web/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/landing/about.html
+++ b/landing/about.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About the game - Gronouy</title>
+  <meta name="description" content="Gameplay loop, environment, and art direction for Gronouy.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Changa:wght@500;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="./">Gronouy</a>
+    <nav class="topnav">
+      <a href="./">Home</a>
+      <a class="play-pill" href="play/">Play now</a>
+    </nav>
+  </header>
+
+  <main class="about-main">
+    <section class="page-head">
+      <p class="jam-line">Design notes</p>
+      <h1>About the game</h1>
+      <p>Why this theme interpretation, how the loop works, and the visual direction behind our jam build.</p>
+    </section>
+
+    <section class="about-block">
+      <h2>Theme and constraint</h2>
+      <p><strong>Theme: Big Brother.</strong> We took it literally: you play the protective big sibling of a huge frog family.</p>
+      <p><strong>Constraint: Procedural Generation.</strong> Every run creates a unique frog: random name, silhouette, and traits.</p>
+    </section>
+
+    <section class="about-block">
+      <h2>Gameplay loop</h2>
+      <ol>
+        <li>Generate a fresh frog with unique stats and look.</li>
+        <li>Explore the pond in all directions in top-down view.</li>
+        <li>Avoid predators and environmental hazards.</li>
+        <li>Find and rescue lost siblings.</li>
+        <li>Unlock evolution milestones and new abilities by surviving longer.</li>
+        <li>If you die, restart with a new big sibling.</li>
+      </ol>
+    </section>
+
+    <section class="about-block">
+      <h2>Environment and dangers</h2>
+      <p>The pond is alive and hostile: lily pads, floating leaves, branches, shallow edges, and constant movement.</p>
+      <ul>
+        <li>Birds patrolling above, diving when they spot you.</li>
+        <li>Fish that chase you in water, with bubble zones as warning signs.</li>
+        <li>Water insects and wasps that punish bad positioning.</li>
+        <li>Currents, toxic zones, and collision-heavy terrain.</li>
+      </ul>
+    </section>
+
+    <section class="about-block">
+      <h2>Art direction</h2>
+      <p>We prioritize readability and speed of production: flat colors, simple textures, and clear silhouettes.</p>
+      <p>This helps us generate many tadpole/frog body variations fast for procedural character assembly. Shadows add depth without complex rendering.</p>
+    </section>
+
+    <section class="about-block">
+      <h2>Character traits and evolution</h2>
+      <p>Procedural traits include speed, size, intelligence, color, and random name.</p>
+      <p>Intelligence also changes style details (for example eye shape or glasses at high intelligence). The more siblings you save, the faster you evolve.</p>
+    </section>
+
+    <section class="about-cta">
+      <a class="btn btn-play" href="play/">Play the game</a>
+      <a class="btn btn-ghost" href="./">Back to home</a>
+    </section>
+  </main>
+
+  <footer>
+    <p>Gronouy: Tadpole's Big Frother - Flame Game Jam 2026.</p>
+  </footer>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gronouy: Tadpole's Big Frother</title>
+  <meta name="description" content="Survive the pond, save your siblings, and evolve. Built for Flame Game Jam 2026.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Changa:wght@500;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="./">Gronouy</a>
+    <nav class="topnav">
+      <a href="about.html">About the game</a>
+      <a class="play-pill" href="play/">Play now</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="jam-line">Flame Game Jam 2026</p>
+      <h1>Gronouy: Tadpole's Big Frother</h1>
+      <p class="hero-copy">A top-down survival roguelite where you are the big sibling of a giant frog family. Explore a dangerous pond, rescue your little siblings, and evolve before predators get you.</p>
+      <div class="hero-ctas">
+        <a class="btn btn-play" href="play/">Play the game</a>
+        <a class="btn btn-ghost" href="about.html">About the game</a>
+      </div>
+      <div class="meta-tags">
+        <span><strong>Theme:</strong> Big Brother</span>
+        <span><strong>Constraint:</strong> Procedural Generation</span>
+      </div>
+    </section>
+
+    <section class="screenshots">
+      <div class="section-title-row">
+        <h2>Screenshots</h2>
+        <p>Placeholders for now</p>
+      </div>
+      <div class="shot-grid">
+        <figure class="shot">
+          <div class="shot-placeholder">Screenshot 1</div>
+          <figcaption>Pond exploration</figcaption>
+        </figure>
+        <figure class="shot">
+          <div class="shot-placeholder">Screenshot 2</div>
+          <figcaption>Sibling rescue moment</figcaption>
+        </figure>
+        <figure class="shot">
+          <div class="shot-placeholder">Screenshot 3</div>
+          <figcaption>Predator encounter</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="quick-pitch">
+      <h2>The pitch</h2>
+      <p>You start each run as a newly generated frog with a random name, shape, color, and traits. Your mission: survive, save siblings, and keep growing. If the big sibling dies, nature continues and a new one takes over in the next run.</p>
+      <a class="inline-link" href="about.html">Read our gameplay and art direction decisions</a>
+    </section>
+  </main>
+
+  <footer>
+    <p>Built with Flame Engine for Flame Game Jam 2026.</p>
+  </footer>
+</body>
+</html>

--- a/landing/style.css
+++ b/landing/style.css
@@ -1,0 +1,221 @@
+:root {
+  --bg: #f4f7f4;
+  --ink: #1c3028;
+  --pond: #1d6a6d;
+  --leaf: #3a8d4f;
+  --sun: #f4c95d;
+  --mist: #d7ebe2;
+  --card: #ffffff;
+  --line: #cae0d6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Nunito", sans-serif;
+  background: radial-gradient(circle at top right, #dff0f2 0%, var(--bg) 45%);
+  color: var(--ink);
+}
+
+h1,
+h2,
+.brand,
+.btn {
+  font-family: "Changa", sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1.1rem;
+  background: color-mix(in srgb, #ffffff 86%, var(--mist) 14%);
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  font-size: 1.4rem;
+  text-decoration: none;
+}
+
+.topnav {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.topnav a {
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.play-pill {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  background: var(--sun);
+}
+
+main {
+  width: min(1080px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  padding: 3.2rem 0 2rem;
+}
+
+.jam-line {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--pond) 80%, black 20%);
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 3.3rem);
+  margin: 0.4rem 0 0.6rem;
+  line-height: 1.02;
+}
+
+.hero-copy {
+  max-width: 70ch;
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.hero-ctas {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.btn {
+  display: inline-block;
+  text-decoration: none;
+  border-radius: 0.8rem;
+  padding: 0.7rem 1.05rem;
+  font-size: 1.02rem;
+}
+
+.btn-play {
+  background: var(--pond);
+  color: white;
+}
+
+.btn-ghost {
+  border: 2px solid var(--pond);
+}
+
+.meta-tags {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.meta-tags span {
+  background: #e9f3ef;
+  border: 1px solid var(--line);
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.45rem;
+}
+
+.screenshots,
+.quick-pitch,
+.about-block,
+.page-head {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-title-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: baseline;
+}
+
+.section-title-row h2 {
+  margin: 0;
+}
+
+.shot-grid {
+  margin-top: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.shot {
+  margin: 0;
+}
+
+.shot-placeholder {
+  aspect-ratio: 16/10;
+  border-radius: 0.9rem;
+  border: 2px dashed #7ab59a;
+  background: linear-gradient(140deg, #d8f1f0, #d8ebd8);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #2d6d54;
+}
+
+figcaption {
+  font-size: 0.95rem;
+  margin-top: 0.35rem;
+}
+
+.quick-pitch h2,
+.about-block h2 {
+  margin-top: 0;
+}
+
+.inline-link {
+  font-weight: 800;
+}
+
+.about-main {
+  padding: 2.2rem 0;
+}
+
+ol,
+ul {
+  padding-left: 1.2rem;
+}
+
+.about-cta {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 2.2rem;
+}
+
+footer {
+  border-top: 1px solid var(--line);
+  padding: 1.2rem;
+  text-align: center;
+  font-weight: 700;
+}
+
+@media (max-width: 850px) {
+  .shot-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a compact English landing page at root with immediate Play now CTA
- move detailed content to about.html (gameplay loop, environment, art direction, character evolution)
- update Pages deploy workflow to publish Flutter game under play/ and keep landing pages at root

## Notes
- screenshots are placeholders for now
- CTA is available in top nav + hero + about page