### PR TITLE
Fix web click-through on menu overlay

### DIFF
--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -19,119 +19,106 @@ class MenuScreen extends StatelessWidget {
     String seed = debugState?.seedCode ?? '-';
     final controller = TextEditingController(text: seed);
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      child: ColoredBox(
-        color: Colors.black.withValues(alpha: 0),
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 420),
-            child: SizedBox(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: SizedBox(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'GRONOUŸ',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 28,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+
+                // Seed input
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const Text(
-                      'GRONOUŸ',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 28,
-                        fontWeight: FontWeight.w700,
+                    Container(
+                      width: 170,
+                      height: 50,
+                      alignment: Alignment.center,
+                      decoration: const BoxDecoration(
+                        image: DecorationImage(
+                          image: AssetImage('assets/images/plank.png'),
+                          fit: BoxFit
+                              .fill, // Ensures the plank stretches to fill the container
+                        ),
+                      ),
+                      child: TextField(
+                        maxLength: 5,
+                        textCapitalization: TextCapitalization.characters,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(
+                            RegExp(r'[a-zA-Z0-9]'),
+                          ),
+                          UpperCaseTextFormatter(),
+                        ],
+                        buildCounter:
+                            (
+                              ctx, {
+                              required int currentLength,
+                              required bool isFocused,
+                              maxLength,
+                            }) => null,
+                        controller: controller,
+                        onChanged: (value) => {
+                          if (value.length == 5)
+                            {
+                              debugPrint('Seed submitted: ${controller.text}'),
+                              seed = controller.text,
+                            },
+                        },
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 6,
+                        ),
+                        decoration: const InputDecoration(
+                          border: InputBorder
+                              .none, // Remove default TextField border
+                          isDense: true, // Reduce height of the TextField
+                          contentPadding:
+                              EdgeInsets.zero, // Remove default padding
+                          hintStyle: TextStyle(letterSpacing: 1.5),
+                        ),
                       ),
                     ),
 
-                    // Seed input
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Container(
-                          width: 170,
-                          height: 50,
-                          alignment: Alignment.center,
-                          decoration: const BoxDecoration(
-                            image: DecorationImage(
-                              image: AssetImage('assets/images/plank.png'),
-                              fit: BoxFit
-                                  .fill, // Ensures the plank stretches to fill the container
-                            ),
-                          ),
-                          child: TextField(
-                            maxLength: 5,
-                            textCapitalization: TextCapitalization.characters,
-                            inputFormatters: [
-                              FilteringTextInputFormatter.allow(
-                                RegExp(r'[a-zA-Z0-9]'),
-                              ),
-                              UpperCaseTextFormatter(),
-                            ],
-                            buildCounter:
-                                (
-                                  ctx, {
-                                  required int currentLength,
-                                  required bool isFocused,
-                                  maxLength,
-                                }) => null,
-                            controller: controller,
-                            onChanged: (value) => {
-                              if (value.length == 5)
-                                {
-                                  debugPrint(
-                                    'Seed submitted: ${controller.text}',
-                                  ),
-                                  seed = controller.text,
-                                },
-                            },
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w500,
-                              letterSpacing: 6,
-                            ),
-                            decoration: const InputDecoration(
-                              border: InputBorder
-                                  .none, // Remove default TextField border
-                              isDense: true, // Reduce height of the TextField
-                              contentPadding:
-                                  EdgeInsets.zero, // Remove default padding
-                              hintStyle: TextStyle(letterSpacing: 1.5),
-                            ),
-                          ),
-                        ),
-
-                        IconButton(
-                          icon: const Icon(
-                            Icons.refresh,
-                            color: Colors.white70,
-                          ),
-                          iconSize: 20,
-                          splashColor:
-                              Colors.transparent, // Keeps it clean looking
-                          highlightColor: Colors.transparent,
-                          onPressed: () {
-                            controller
-                                .clear(); // Clears the text field visually
-                            debugPrint('Seed reset');
-                            onReroll();
-                            // If you need to trigger a game event, do it here!
-                          },
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 20),
-                    _CharacterDebugPanel(debugState: debugState),
-                    const SizedBox(height: 12),
-
-                    const SizedBox(height: 12),
-                    const Text(
-                      'Move: WASD/Arrows  Jump: Space  Pause: Esc',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(color: Colors.white60),
+                    IconButton(
+                      icon: const Icon(Icons.refresh, color: Colors.white70),
+                      iconSize: 20,
+                      splashColor: Colors.transparent, // Keeps it clean looking
+                      highlightColor: Colors.transparent,
+                      onPressed: () {
+                        controller.clear(); // Clears the text field visually
+                        debugPrint('Seed reset');
+                        onReroll();
+                        // If you need to trigger a game event, do it here!
+                      },
                     ),
                   ],
                 ),
-              ),
+
+                const SizedBox(height: 20),
+                _CharacterDebugPanel(debugState: debugState),
+                const SizedBox(height: 12),
+
+                const SizedBox(height: 12),
+                const Text(
+                  'Move: WASD/Arrows  Jump: Space  Pause: Esc',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.white60),
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
Removed the opaque `GestureDetector` wrapper that was preventing click-through events on the menu overlay, allowing web interactions to pass through to underlying elements. This simplifies the widget tree while fixing web-specific input handling issues.

Closes #28