### PR TITLE
Add multi-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,295 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: Optional extra release notes
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      build_number: ${{ steps.meta.outputs.build_number }}
+      version_name: ${{ steps.meta.outputs.version_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute release metadata
+        id: meta
+        run: |
+          build="$(git rev-list --count HEAD)"
+
+          version_name='0.0.0'
+          tag="v${version_name}+${build}"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "build_number=$build" >> "$GITHUB_OUTPUT"
+          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          EXTRA_NOTES: ${{ inputs.notes }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+          {
+            echo "# $TAG"
+            echo
+            if [[ -n "$last_tag" ]]; then
+              echo "Changes since $last_tag:"
+              echo
+              git log --no-merges --pretty=format:'- %s (%h)' "$last_tag..HEAD"
+            else
+              echo "Changes:"
+              echo
+              git log --no-merges --pretty=format:'- %s (%h)'
+            fi
+            echo
+            if [[ -n "$EXTRA_NOTES" ]]; then
+              echo
+              echo "## Notes"
+              echo
+              echo "$EXTRA_NOTES"
+            fi
+          } > RELEASE_NOTES.md
+
+          if ! grep -q '^- ' RELEASE_NOTES.md; then
+            {
+              echo
+              echo "- Initial release"
+            } >> RELEASE_NOTES.md
+          fi
+
+      - name: Create git tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            exit 1
+          fi
+
+          gh api "repos/${{ github.repository }}/git/refs" \
+            --method POST \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$SHA"
+
+      - name: Create or update draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --draft --title "$TAG" --notes-file RELEASE_NOTES.md
+          else
+            gh release create "$TAG" --draft --title "$TAG" --notes-file RELEASE_NOTES.md
+          fi
+
+  build_android:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build Android APK
+        run: |
+          flutter build apk --release \
+            --build-name "${{ needs.prepare.outputs.version_name }}" \
+            --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+  build_ios:
+    runs-on: macos-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build iOS (no codesign)
+        run: |
+          flutter build ios --release --no-codesign \
+            --build-name "${{ needs.prepare.outputs.version_name }}" \
+            --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Package iOS artifact
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent \
+            build/ios/iphoneos/Runner.app \
+            game-jam-ios-runner.app.zip
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-runner-zip
+          path: game-jam-ios-runner.app.zip
+
+  build_windows:
+    runs-on: windows-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build Windows
+        shell: bash
+        run: flutter build windows --release --build-name "${{ needs.prepare.outputs.version_name }}" --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Package Windows artifact
+        shell: pwsh
+        run: Compress-Archive -Path "build/windows/x64/runner/Release/*" -DestinationPath "game-jam-windows-release.zip"
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release-zip
+          path: game-jam-windows-release.zip
+
+  build_macos:
+    runs-on: macos-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build macOS
+        run: |
+          flutter build macos --release \
+            --build-name "${{ needs.prepare.outputs.version_name }}" \
+            --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Package macOS artifact
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent \
+            build/macos/Build/Products/Release/Runner.app \
+            game-jam-macos-runner.app.zip
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-runner-zip
+          path: game-jam-macos-runner.app.zip
+
+  build_linux:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build Linux
+        run: |
+          flutter build linux --release \
+            --build-name "${{ needs.prepare.outputs.version_name }}" \
+            --build-number "${{ needs.prepare.outputs.build_number }}"
+
+      - name: Package Linux artifact
+        run: tar -czf game-jam-linux-bundle.tar.gz -C build/linux/x64/release bundle
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bundle-tar
+          path: game-jam-linux-bundle.tar.gz
+
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build_android
+      - build_ios
+      - build_windows
+      - build_macos
+      - build_linux
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Upload artifacts to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find release-artifacts -type f \( -name '*.apk' -o -name '*.zip' -o -name '*.tar.gz' \))
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No artifacts found"
+            exit 1
+          fi
+          gh release upload "$TAG" "${files[@]}" --clobber
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false


### PR DESCRIPTION
Added a multi-platform release workflow that automates building and publishing Flutter app artifacts for Android, iOS, Windows, macOS, and Linux. The workflow generates release metadata, creates git tags, builds platform-specific binaries, and uploads them to a GitHub release on manual trigger. This enables consistent, automated releases across all supported platforms with generated changelogs.

Closes #30