### PR TITLE
Fix restart when clicking character mid-game

### DIFF
--- a/lib/game/my_game.dart
+++ b/lib/game/my_game.dart
@@ -222,6 +222,10 @@ class MyGame extends FlameGame<WorldRoot>
   }
 
   void startGame() {
+    if (phase.value != GamePhase.menu && phase.value != GamePhase.gameOver) {
+      return;
+    }
+
     world.reset();
     phase.value = GamePhase.playing;
     resumeEngine();

--- a/test/game_init_test.dart
+++ b/test/game_init_test.dart
@@ -6,4 +6,13 @@ void main() {
     final MyGame game = MyGame();
     expect(game.phase.value, GamePhase.menu);
   });
+
+  test('startGame is ignored while paused', () {
+    final MyGame game = MyGame();
+    game.phase.value = GamePhase.paused;
+
+    game.startGame();
+
+    expect(game.phase.value, GamePhase.paused);
+  });
 }


### PR DESCRIPTION
Prevent accidental game restart when clicking character selection during gameplay by adding a guard clause to `startGame()` that only allows transitions from menu or game-over states. This fixes unintended restarts triggered by mid-game character interactions. Added test coverage to verify the guard prevents state changes when game is already in progress.

Closes #33 