### PR TITLE
Update collision page performance

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,20 +28,25 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
       - name: Build web
-        run: flutter build web --wasm --release --base-href /play/
+        run: flutter build web --wasm --release --pwa-strategy=none --base-href /play/
 
       - name: Move game under /play and add landing pages
         run: |
           temp_dir="$(mktemp -d)"
-          mv build/web/* "$temp_dir"/
+          cp -a build/web/. "$temp_dir"/
+          rm -rf build/web
           mkdir -p build/web/play
-          mv "$temp_dir"/* build/web/play/
-          cp -R landing/. build/web/
+          cp -a "$temp_dir"/. build/web/play/
+          cp -a landing/. build/web/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/lib/game/components/enemies/bird_enemy_component.dart
+++ b/lib/game/components/enemies/bird_enemy_component.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flame/collisions.dart';
@@ -35,6 +36,8 @@ class BirdEnemyComponent extends SpriteAnimationComponent
     : super(priority: 100, size: minSize, position: initialPosition);
 
   PositionComponent? _target;
+  ShadowComponent? _shadow;
+  CircleHitbox? _hitbox;
   bool _isScaled = false;
 
   /// When true, only the shadow is visible and moves; bird appears when player hovers.
@@ -60,6 +63,9 @@ class BirdEnemyComponent extends SpriteAnimationComponent
   static const double _damageInterval = PhysicsTuning.birdEnemyDamageInterval;
   static const double _damageRange = PhysicsTuning.birdEnemyDamageRange;
   static const int _damageAmount = PhysicsTuning.birdEnemyDamageAmount;
+  static final Paint _transparentPaint = Paint()..color = Colors.transparent;
+  final Paint _birdPaint = Paint()..color = Colors.white;
+  final Paint _shadowPaint = Paint()..color = Colors.black;
 
   static bool shouldRunForPhase(GamePhase phase) {
     return phase == GamePhase.playing;
@@ -78,18 +84,16 @@ class BirdEnemyComponent extends SpriteAnimationComponent
     );
     _pickNewDirection();
 
-    add(
-      CircleHitbox(
-        radius: initialSize.x,
-        position: Vector2(initialSize.x, initialSize.y),
-      ),
+    _hitbox = CircleHitbox(
+      radius: initialSize.x,
+      position: Vector2(initialSize.x, initialSize.y),
     );
-    add(
-      ShadowComponent(
-        position: _shadowPositionFor(size: initialSize, facingRight: true),
-        radius: initialSize.x,
-      ),
+    _shadow = ShadowComponent(
+      position: _shadowPositionFor(size: initialSize, facingRight: true),
+      radius: initialSize.x,
     );
+    add(_hitbox!);
+    add(_shadow!);
 
     await super.onLoad();
   }
@@ -100,7 +104,7 @@ class BirdEnemyComponent extends SpriteAnimationComponent
   }
 
   @override
-  Future<void> update(double dt) async {
+  void update(double dt) {
     if (!shouldRunForPhase(game.phase.value)) {
       super.update(dt);
       return;
@@ -110,8 +114,7 @@ class BirdEnemyComponent extends SpriteAnimationComponent
       _pendingRecreateShadowAndHitbox = false;
       // Defer add until after this frame's update tree and collisionDetection.run()
       // so the collision system sees the pair as ended before the new hitbox exists.
-      // ignore: unawaited_futures
-      Future.microtask(_recreateShadowAndHitboxForShadowOnly);
+      unawaited(Future<void>.microtask(_recreateShadowAndHitboxForShadowOnly));
     }
 
     final target = _target;
@@ -170,7 +173,7 @@ class BirdEnemyComponent extends SpriteAnimationComponent
   }
 
   void _updateShadowOnly(double dt) {
-    paint = Paint()..color = Colors.transparent;
+    paint = _transparentPaint;
     _updateMovingShadow(dt);
     _animateShadowPulse(dt);
   }
@@ -211,7 +214,7 @@ class BirdEnemyComponent extends SpriteAnimationComponent
     followComponent(_speed, dt, target);
     _scaleUpComponent(target);
     _scaleDownShadow(target);
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
+    final ShadowComponent? shadow = _shadow;
     if (shadow != null) {
       shadow.position = _shadowPositionFor(size: size);
     }
@@ -256,26 +259,29 @@ class BirdEnemyComponent extends SpriteAnimationComponent
     final verticalOffset = _descentHeight * (1 - t);
     final birdCenter = mergeCenter + Vector2(0, -verticalOffset);
     position = birdCenter - size / 2;
-    paint = Paint()..color = Colors.white.withValues(alpha: t);
+    _birdPaint.color = Colors.white.withValues(alpha: t);
+    paint = _birdPaint;
 
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
+    final ShadowComponent? shadow = _shadow;
     if (shadow != null) {
       shadow.position = mergeCenter - position;
       shadow.scale = Vector2.all(1 - t);
-      shadow.paint = Paint()
-        ..color = Colors.black.withValues(alpha: (1 - t).clamp(0.0, 0.5));
+      _shadowPaint.color = Colors.black.withValues(
+        alpha: (1 - t).clamp(0.0, 0.5),
+      );
+      shadow.paint = _shadowPaint;
     }
   }
 
   void _finishDescent() {
     _isScaled = true;
     _descentProgress = null;
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
+    final ShadowComponent? shadow = _shadow;
     if (shadow != null) {
       shadow.position = _shadowPositionFor(size: initialSize);
       shadow.scale = Vector2.all(1);
     }
-    final hitbox = children.whereType<CircleHitbox>().firstOrNull;
+    final CircleHitbox? hitbox = _hitbox;
     if (hitbox != null) {
       hitbox.position = initialSize / 2;
     }
@@ -302,28 +308,26 @@ class BirdEnemyComponent extends SpriteAnimationComponent
   /// Removes shadow and hitbox so the collision system can clear the active
   /// pair (bird hitbox, player). Called when finishing ascend.
   void _removeShadowAndHitbox() {
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
-    final hitbox = children.whereType<CircleHitbox>().firstOrNull;
-    shadow?.removeFromParent();
-    hitbox?.removeFromParent();
+    _shadow?.removeFromParent();
+    _hitbox?.removeFromParent();
+    _shadow = null;
+    _hitbox = null;
   }
 
   /// Re-adds shadow and hitbox. Called at the start of the next frame after
   /// _removeShadowAndHitbox so Flame's collision run sees the pair ended
   /// before the new hitbox exists (fixes "collision only once").
   Future<void> _recreateShadowAndHitboxForShadowOnly() async {
-    add(
-      CircleHitbox(
-        radius: initialSize.x,
-        position: Vector2(initialSize.x, initialSize.y),
-      ),
+    _hitbox = CircleHitbox(
+      radius: initialSize.x,
+      position: Vector2(initialSize.x, initialSize.y),
     );
-    add(
-      ShadowComponent(
-        position: Vector2(initialSize.x, initialSize.y),
-        radius: initialSize.x,
-      ),
+    _shadow = ShadowComponent(
+      position: Vector2(initialSize.x, initialSize.y),
+      radius: initialSize.x,
     );
+    add(_hitbox!);
+    add(_shadow!);
   }
 
   void _updateFacingToward(PositionComponent target) {
@@ -350,7 +354,7 @@ class BirdEnemyComponent extends SpriteAnimationComponent
 
   void _animateShadowPulse(double dt) {
     _shadowPulseTime += dt;
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
+    final ShadowComponent? shadow = _shadow;
     if (shadow == null) return;
     final pulse = 0.92 + 0.08 * (1 + sin(_shadowPulseTime * 3));
     shadow.scale = Vector2.all(pulse);
@@ -381,14 +385,16 @@ class BirdEnemyComponent extends SpriteAnimationComponent
 
   void _scaleDownShadow(PositionComponent target) {
     if (_isScaled) return;
-    final shadow = children.whereType<ShadowComponent>().firstOrNull;
+    final ShadowComponent? shadow = _shadow;
     if (shadow == null) return;
     final distance = position.distanceTo(target.position);
     final t = 1 - (distance / _scaleUpDistance).clamp(0.0, 1.0);
-    shadow.paint = Paint()
-      ..color = Colors.black.withValues(alpha: (1 - t).clamp(0.0, 0.5));
+    _shadowPaint.color = Colors.black.withValues(
+      alpha: (1 - t).clamp(0.0, 0.5),
+    );
+    shadow.paint = _shadowPaint;
     if (distance <= 0) {
-      shadow.paint = Paint()..color = Colors.transparent;
+      shadow.paint = _transparentPaint;
     }
   }
 
@@ -400,9 +406,11 @@ class BirdEnemyComponent extends SpriteAnimationComponent
     }
     final t = 1 - (distance / _scaleUpDistance).clamp(0.0, 1.0);
     size = minSize + (initialSize - minSize) * t;
-    paint = Paint()..color = Colors.black.withValues(alpha: 1 * t);
+    _birdPaint.color = Colors.black.withValues(alpha: t);
+    paint = _birdPaint;
     if (distance <= 0) {
-      paint = Paint()..color = Colors.black.withValues(alpha: 1);
+      _birdPaint.color = Colors.black.withValues(alpha: 1);
+      paint = _birdPaint;
       size = initialSize;
       _isScaled = true;
     }

--- a/lib/game/components/enemies/fish_enemy_component.dart
+++ b/lib/game/components/enemies/fish_enemy_component.dart
@@ -15,6 +15,9 @@ class FishEnemyComponent extends SpriteAnimationComponent
   PositionComponent? target;
   bool isEating = false;
   double timeSinceStartingEat = 0;
+  late final List<Sprite> _sprites;
+  late final SpriteAnimation _idleAnimation;
+  late final SpriteAnimation _eatAnimation;
 
   FishEnemyComponent({required this.initialPosition, required this.initialSize})
     : super(
@@ -29,7 +32,71 @@ class FishEnemyComponent extends SpriteAnimationComponent
   @override
   Future<void> onLoad() async {
     await super.onLoad();
-    animation = idleAnimation;
+    _sprites = List<Sprite>.generate(AssetPaths.croqueAnimationFrames, (index) {
+      final int frameNumber = index;
+      return Sprite(
+        game.images.fromCache(
+          '${AssetPaths.croqueAnimationPrefix}$frameNumber.png',
+        ),
+      );
+    }, growable: false);
+    _idleAnimation = SpriteAnimation.spriteList([
+      _sprites[19],
+    ], stepTime: _stepTimeInS);
+    _eatAnimation = SpriteAnimation.variableSpriteList(
+      <int>[
+        19,
+        18,
+        17,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+      ].map((i) => _sprites[i]).toList(growable: false),
+      stepTimes: <int>[
+        3,
+        2,
+        3,
+        4,
+        4,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        3,
+        2,
+        2,
+        2,
+        1,
+        2,
+        2,
+        3,
+      ].map((frame) => frame * _stepTimeInS).toList(growable: false),
+      loop: false,
+    );
+    animation = _idleAnimation;
     add(
       CircleHitbox(
         radius: (initialSize.x / 3),
@@ -40,7 +107,7 @@ class FishEnemyComponent extends SpriteAnimationComponent
   }
 
   @override
-  void update(double dt) async {
+  void update(double dt) {
     super.update(dt);
     if (!isEating && timeSinceStartingEat != 0) {
       timeSinceStartingEat = 0;
@@ -52,9 +119,11 @@ class FishEnemyComponent extends SpriteAnimationComponent
         target != null &&
         timeSinceStartingEat <= deathTimeInS + 0.6) {
       if (target is PlayerComponent) {
-        await (target as PlayerComponent).applyDamageWithInvincibilityDelay(
-          50,
-          1.0,
+        unawaited(
+          (target as PlayerComponent).applyDamageWithInvincibilityDelay(
+            50,
+            1.0,
+          ),
         );
       } else {
         target?.removeFromParent();
@@ -84,12 +153,12 @@ class FishEnemyComponent extends SpriteAnimationComponent
   void startEating() async {
     if (isEating) return;
     isEating = true;
-    animation = eatAnimation;
+    animation = _eatAnimation;
     paint.blendMode = BlendMode.srcOver;
     await Future.delayed(
       Duration(milliseconds: (animationsTimeInS * 1000).toInt()),
       () {
-        animation = idleAnimation;
+        animation = _idleAnimation;
         isEating = false;
         paint.blendMode = BlendMode.screen;
       },
@@ -105,71 +174,4 @@ class FishEnemyComponent extends SpriteAnimationComponent
 
   static const double animationsTimeInS = _stepTimeInS * totalFrames;
   static const double deathTimeInS = closingMouthFrame * _stepTimeInS;
-
-  List<Sprite> get spriteList =>
-      List<Sprite>.generate(AssetPaths.croqueAnimationFrames, (index) {
-        final frameNumber = index;
-        return Sprite(
-          game.images.fromCache(
-            '${AssetPaths.croqueAnimationPrefix}$frameNumber.png',
-          ),
-        );
-      });
-  SpriteAnimation get idleAnimation =>
-      SpriteAnimation.spriteList([spriteList[19]], stepTime: _stepTimeInS);
-
-  SpriteAnimation get eatAnimation => SpriteAnimation.variableSpriteList(
-    [
-      19,
-      18,
-      17,
-      0,
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15,
-      16,
-      17,
-      18,
-      19,
-    ].map((i) => spriteList[i]).toList(),
-
-    stepTimes: [
-      3,
-      2,
-      3,
-      4,
-      4,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      3,
-      2,
-      2,
-      2,
-      1,
-      2,
-      2,
-      3,
-    ].map((frame) => frame * _stepTimeInS).toList(),
-    loop: false,
-  );
 }

--- a/lib/game/components/environment/frog_house_component.dart
+++ b/lib/game/components/environment/frog_house_component.dart
@@ -24,7 +24,7 @@ class FrogHouseComponent extends SpriteComponent
   }
 
   @override
-  Future<void> update(double dt) async {
+  void update(double dt) {
     final savedEggs = children
         .whereType<EggComponent>()
         .where((egg) => egg.isInSafeHouse)

--- a/lib/game/components/environment/ground_component.dart
+++ b/lib/game/components/environment/ground_component.dart
@@ -19,6 +19,6 @@ class GroundComponent extends RectangleComponent
   @override
   Future<void> onLoad() async {
     await super.onLoad();
-    add(RectangleHitbox(size: size));
+    add(RectangleHitbox(size: size, collisionType: CollisionType.passive));
   }
 }

--- a/lib/game/components/environment/water_component.dart
+++ b/lib/game/components/environment/water_component.dart
@@ -19,6 +19,12 @@ class WaterComponent extends SpriteComponent with HasGameReference<MyGame> {
   @override
   Future<void> onLoad() async {
     await super.onLoad();
-    add(RectangleHitbox(size: size, priority: 1));
+    add(
+      RectangleHitbox(
+        size: size,
+        priority: 1,
+        collisionType: CollisionType.passive,
+      ),
+    );
   }
 }

--- a/lib/game/components/player/player_component.dart
+++ b/lib/game/components/player/player_component.dart
@@ -93,7 +93,7 @@ class PlayerComponent extends SpriteAnimationComponent
   bool get _isTouchingLily => _lilyContacts > 0;
   bool get _isTouchingFrogHouse => _frogHouseContacts > 0;
 
-  bool get _isMoving => velocity.length2 > 0;
+  bool get _isMoving => inputState.moveAxisX != 0 || inputState.moveAxisY != 0;
   bool _wasMoving = false;
 
   Vector2 get velocity =>
@@ -191,6 +191,21 @@ class PlayerComponent extends SpriteAnimationComponent
       velocity.normalize();
     }
     return velocity;
+  }
+
+  double _movementDot(Vector2 normal) {
+    double x = inputState.moveAxisX;
+    double y = inputState.moveAxisY;
+    final double length2 = (x * x) + (y * y);
+    if (length2 == 0) {
+      return 0;
+    }
+    if (length2 > 1) {
+      final double invLength = 1 / sqrt(length2);
+      x *= invLength;
+      y *= invLength;
+    }
+    return (x * normal.x) + (y * normal.y);
   }
 
   static bool shouldRenderGlasses(double intelligence) {
@@ -410,6 +425,11 @@ class PlayerComponent extends SpriteAnimationComponent
   @override
   void update(double dt) {
     super.update(dt);
+    final Vector2 movement = normalizeMoveAxis(
+      inputState.moveAxisX,
+      inputState.moveAxisY,
+    );
+    final bool isMoving = movement.length2 > 0;
     if (isInWater) {
       _underwaterSurfaceGraceRemaining =
           PhysicsTuning.underwaterSurfaceGraceSeconds;
@@ -429,7 +449,7 @@ class PlayerComponent extends SpriteAnimationComponent
 
     _syncMovementAnimation();
 
-    if (!isInWater && _isMoving) {
+    if (!isInWater && isMoving) {
       _hopTime += dt;
     } else {
       _hopTime = 0.0;
@@ -437,7 +457,7 @@ class PlayerComponent extends SpriteAnimationComponent
     final double hopScale = isInWater ? 1.0 : sin(_hopTime * 8.0).abs();
 
     position +=
-        velocity *
+        movement *
         PhysicsTuning.playerMoveSpeed *
         _speedMultiplier *
         dt *
@@ -451,10 +471,10 @@ class PlayerComponent extends SpriteAnimationComponent
             PhysicsTuning.thornKnockbackMinSpeed) {
       _thornKnockbackVelocity.setZero();
     }
-    _wasMoving = _isMoving;
+    _wasMoving = isMoving;
 
-    final double targetAngle = velocity.screenAngle();
-    if (velocity.x != 0 || velocity.y != 0) {
+    final double targetAngle = movement.screenAngle();
+    if (movement.x != 0 || movement.y != 0) {
       final double angleDelta = _shortestAngleDelta(targetAngle, angle);
       if (angleDelta != 0) {
         final double maxStep =
@@ -707,7 +727,7 @@ class PlayerComponent extends SpriteAnimationComponent
           final collisionNormal = absoluteCenter - mid;
           final separationDistance = (size.x / 2) - collisionNormal.length;
           collisionNormal.normalize();
-          final double moveDot = velocity.dot(collisionNormal);
+          final double moveDot = _movementDot(collisionNormal);
           if (moveDot < 0 || separationDistance > 1.5) {
             position += collisionNormal.scaled(separationDistance);
           }
@@ -738,7 +758,7 @@ class PlayerComponent extends SpriteAnimationComponent
           final collisionNormal = absoluteCenter - mid;
           final separationDistance = (size.x / 2) - collisionNormal.length;
           collisionNormal.normalize();
-          final double moveDot = velocity.dot(collisionNormal);
+          final double moveDot = _movementDot(collisionNormal);
           if (moveDot < 0 || separationDistance > 1.5) {
             position += collisionNormal.scaled(separationDistance);
           }

--- a/lib/game/world/generated_level.dart
+++ b/lib/game/world/generated_level.dart
@@ -8,18 +8,36 @@ import 'package:game_jam/game/world/world_mixin.dart';
 class GeneratedLevel extends Component
     with HasGameReference<MyGame>, WorldMixin {
   late BiomeType biome;
+  List<_AxisAlignedBounds> _waterBounds = <_AxisAlignedBounds>[];
 
   @override
   Future<void> onLoad() async {
     biome = computeBiome();
     await generateLevel(biome);
+    _rebuildWaterBounds();
     await super.onLoad();
   }
 
   Future<void> onUpdateSeed() async {
     removeAll(children);
+    _waterBounds = <_AxisAlignedBounds>[];
     biome = computeBiome();
     await generateLevel(biome);
+    _rebuildWaterBounds();
+  }
+
+  void _rebuildWaterBounds() {
+    _waterBounds = children
+        .whereType<WaterComponent>()
+        .map(
+          (WaterComponent water) => _AxisAlignedBounds(
+            left: water.position.x,
+            top: water.position.y,
+            right: water.position.x + water.size.x,
+            bottom: water.position.y + water.size.y,
+          ),
+        )
+        .toList(growable: false);
   }
 
   bool isPositionOnThorn(Vector2 position) {
@@ -38,17 +56,32 @@ class GeneratedLevel extends Component
   }
 
   bool isPositionInWater(Vector2 position) {
-    for (final WaterComponent water in children.whereType<WaterComponent>()) {
-      final bool insideX =
-          position.x >= water.position.x &&
-          position.x <= water.position.x + water.size.x;
-      final bool insideY =
-          position.y >= water.position.y &&
-          position.y <= water.position.y + water.size.y;
-      if (insideX && insideY) {
+    for (final _AxisAlignedBounds bounds in _waterBounds) {
+      if (bounds.contains(position)) {
         return true;
       }
     }
     return false;
+  }
+}
+
+class _AxisAlignedBounds {
+  const _AxisAlignedBounds({
+    required this.left,
+    required this.top,
+    required this.right,
+    required this.bottom,
+  });
+
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  bool contains(Vector2 point) {
+    return point.x >= left &&
+        point.x <= right &&
+        point.y >= top &&
+        point.y <= bottom;
   }
 }


### PR DESCRIPTION
Optimized runtime performance through object reuse and eliminated unnecessary allocations, and fixed web deployment build by disabling PWA caching strategy while improving file operations in the GitHub Pages workflow.